### PR TITLE
Implement GitHub workflows for purging outdated workflow runs

### DIFF
--- a/.github/workflows/workflow-runs-purge-dispatch.yml
+++ b/.github/workflows/workflow-runs-purge-dispatch.yml
@@ -1,0 +1,60 @@
+# Workflow for removing old workflow runs manually
+#
+# See workflow-runs-purge.yml
+name: Delete old workflow runs manually
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days."
+        required: true
+        default: 30
+      minimum_runs:
+        description: "The minimum runs to keep for each workflow."
+        required: true
+        default: 6
+      delete_workflow_pattern:
+        description: "The name or filename of the workflow. if not set then it will target all workflows."
+        required: false
+      delete_workflow_by_state_pattern:
+        description: "Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually"
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description: "Remove workflow by conclusion: action_required, cancelled, failure, skipped, success"
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: "Only log actions, do not perform any delete operations."
+        required: false
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
+          delete_run_by_conclusion_pattern: ${{ github.event.inputs.delete_run_by_conclusion_pattern }}
+          dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/workflow-runs-purge.yml
+++ b/.github/workflows/workflow-runs-purge.yml
@@ -1,0 +1,24 @@
+# Workflow automatically executed so that to clean up workflow runs pilling in the GitHub Actions tab
+#
+# By default, workflow runs older than 30 days (see 'retain_days' parameter) are removed, every day at
+# midnight (see and 'cron' parameters, respectively).
+# A token with the necessary permission for deleting workflow runs must be provided or the 'github.token'
+# can also be used.
+name: Purge workflow runs automatically
+
+on:
+  schedule:
+    # Execute the job every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 30
+          keep_minimum_runs: 6


### PR DESCRIPTION
## Description

This pull request (PR) aims at:

- Implementing GitHub workflows for manually (i.e. triggered by [`workflow_dispatch`](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually) event) and automatically (using [`cron`](https://man7.org/linux/man-pages/man8/cron.8.html) job) remove old workflow runs piling in the [GitHub Actions](https://github.com/SofairOfficial/rust-project-template/actions) tab 

## Related issues

This PR closes #4 

## How has this been tested?

- The workflows can be tested locally, using the [Act](https://github.com/nektos/act) tool or using the [GitHub Actions Runner](https://github.com/actions/runner). See image below as an example of using Act for testing the manual (i.e. triggered when `workflow_dispatch` event occured):
![Screenshot 2023-03-12 at 12 30 27](https://user-images.githubusercontent.com/61555648/224542140-f7ccf0a2-374e-443a-b75d-7728690dc5bf.png)
Note that a GitHub [Personal Access Token](https://github.com/settings/tokens) (PAT), a classic one, must be passed as `-s GITHUB_TOKEN = [your_PAT_here]` argument to [Act](https://github.com/nektos/act#github_token).

**Test configuration**:
* Firmware version: -
* OS: Mac OS - Ventura 13.2.1
* Toolchain: [Act](https://github.com/nektos/act) and [`GitHub CLI`](https://cli.github.com/) 
* SDK: -

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
