### PR TITLE
Prevent merging for pull requests in progress (#11)

### DIFF
--- a/.github/workflows/check-label-in-progress.yml
+++ b/.github/workflows/check-label-in-progress.yml
@@ -1,0 +1,17 @@
+name: Check label in-progress to prevent merging
+
+on:
+  pull_request_target:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: "${{ contains(github.event.*.labels.*.name, 'status: in progress') }}"
+    name: Check do not merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: check for label
+        run: |
+          echo "Pull request is labeled as 'status: in progress'"
+          echo "This workflow fails to prevent merging"
+          exit 1

--- a/.github/workflows/check-label-in-progress.yml
+++ b/.github/workflows/check-label-in-progress.yml
@@ -1,3 +1,6 @@
+# Workflow automatically executed to check if a pull request has label `status: in progress` to prevent
+# merging incomplete work
+
 name: Check label in-progress to prevent merging
 
 on:

--- a/.github/workflows/workflow-runs-purge.yml
+++ b/.github/workflows/workflow-runs-purge.yml
@@ -22,3 +22,11 @@ jobs:
           repository: ${{ github.repository }}
           retain_days: 30
           keep_minimum_runs: 6
+      - name: Delete runs of wpurge workflow run
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          delete_workflow_pattern: "Purge workflow runs automatically"
+          retain_days: 3
+          keep_minimum_runs: 3

--- a/.github/workflows/workflow-runs-purge.yml
+++ b/.github/workflows/workflow-runs-purge.yml
@@ -1,7 +1,8 @@
 # Workflow automatically executed so that to clean up workflow runs pilling in the GitHub Actions tab
 #
 # By default, workflow runs older than 30 days (see 'retain_days' parameter) are removed, every day at
-# midnight (see and 'cron' parameters, respectively).
+# midnight (see and 'cron' parameters, respectively). The workflow purges his own run to only keep
+# 3 of them in a second step (see 'keep_minimum runs').
 # A token with the necessary permission for deleting workflow runs must be provided or the 'github.token'
 # can also be used.
 name: Purge workflow runs automatically
@@ -22,7 +23,7 @@ jobs:
           repository: ${{ github.repository }}
           retain_days: 30
           keep_minimum_runs: 6
-      - name: Delete runs of wpurge workflow run
+      - name: Delete runs of purge workflow runs
         uses: Mattraks/delete-workflow-runs@v2
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
## Description

This pull request aims to prevent merging of an incomplete work by checking the `status: in progress` label.
Moreover, it adds a delete scheme to autodelete `Purge workflows runs automatically` after its own run.


## Related issues
  
closes #10

## How has this been tested?

The tests were performed on another test repository.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
